### PR TITLE
Set en language in test

### DIFF
--- a/tests/codeception/config/config.php
+++ b/tests/codeception/config/config.php
@@ -3,6 +3,7 @@
  * Application configuration shared by all test types
  */
 return [
+    'language' => 'en-US',
     'controllerMap' => [
         'fixture' => [
             'class' => 'yii\faker\FixtureController',


### PR DESCRIPTION
When I change language to `ru` then `my` tests works, but Yii tests doesn't works.

To corrects this behavior added in test config
```
'language' => 'en-US',
```
