### PR TITLE
Add `cookieValidationKey` setting to the `Install from an Archive File`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ INSTALLATION
 Extract the archive file downloaded from [yiiframework.com](http://www.yiiframework.com/download/) to
 a directory named `basic` that is directly under the Web root.
 
+Set cookie validation key in `config/web.php` file to some random secret string:
+
+```php
+'request' => [
+    // !!! insert a secret key in the following (if it is empty) - this is required by cookie validation
+    'cookieValidationKey' => '<secret random string goes here>',
+],
+```
+
 You can then access the application through the following URL:
 
 ~~~


### PR DESCRIPTION
Without this, basic application doesn’t work.