### PR TITLE
Add step to setup config file path in c3.php

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -90,6 +90,8 @@ from codeception site.
 
 3. include `c3.php` file in your `index-test.php` file before application run, so it can catch needed requests.
 
+4. edit `c3.php` to update config file path (~ line 55) with `$config_file = realpath(__DIR__ . '../tests/codeception.yml');`
+
 Configuration options that are used by remote code coverage:
 
 - c3_url: url pointing to entry script that includes `c3.php` file, so `Codeception` will be able to produce code coverage;


### PR DESCRIPTION
Hi,

I've been struggling in making remote code coverage work and I finally figured out that the config file path was wrong.
I haven't seen any documentation telling to update that path (weird).

Furthermore, it is kind of impossible to debug as it generates a corrupted tar file (because of the error generated by the wrong config file path probably) that ends up by having an non-related error message (like "unable to decompress gzipped phar archive").

There is another way to do it, by setting the env var HTTP_X_CODECEPTION_CODECOVERAGE_CONFIG but, even though I don't like changing manually c3.php, I still prefer that than using env var as it wouldn't be linked anymore with your project but with your environment (that can be shared with other projects) settings.
And I don't know if it would be possible that codeception set this var (as it actually knows the path) to make it available to c3.php, in fact I haven't seen anything setting this var up in codeception code.

Cheers,
Nico