### PR TITLE
Modified default @tests value and updated READMEs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ return [
 ];
 ```
 
-**NOTE:** Yii won't create the database for you, this has to be done manually before you can access it.
-
-Also check and edit the other files in the `config/` directory to customize your application.
+**NOTES:**
+- Yii won't create the database for you, this has to be done manually before you can access it.
+- Check and edit the other files in the `config/` directory to customize your application as required.
+- Refer to the README in the `tests` direcotry for information specific to basic application tests.

--- a/config/console.php
+++ b/config/console.php
@@ -1,6 +1,6 @@
 <?php
 
-Yii::setAlias('@tests', dirname(__DIR__) . '/tests');
+Yii::setAlias('@tests', dirname(__DIR__) . '/tests/codeception');
 
 $params = require(__DIR__ . '/params.php');
 $db = require(__DIR__ . '/db.php');
@@ -25,6 +25,13 @@ $config = [
         'db' => $db,
     ],
     'params' => $params,
+    /*
+    'controllerMap' => [
+        'fixture' => [ // Fixture generation command line.
+            'class' => 'yii\faker\FixtureController',
+        ],
+    ],
+    */
 ];
 
 if (YII_ENV_DEV) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -62,6 +62,17 @@ webserver. In the `web` directory execute the following:
    codecept run unit
    ```
 
+Fixtures Default Configuration
+------------------------------
+The `fixture` commands refer to the following `ActiveFixture` configuration by default:
+
+- Fixtures path: `@tests/unit/fixtures`
+- Fixtures data path: `@tests/unit/fixtures/data`
+- Template files path: `@tests/unit/templates/fixtures`
+- Namespace: `tests\unit\fixtures`
+
+Where `@tests` refers to `@app/tests/codeception`.
+
 Code coverage support
 ---------------------
 


### PR DESCRIPTION
Modifications to address yiisoft/yii2-app-basic#14

- Updated codeception version to 2.1 in tests README instructions.
- Changed the default value of alias `@tests` to `/tests/codeception`.
- Added a section in the tests README for the default fixture paths.
- Added a reference to the tests README in the main README to avoid overlooking the former.
- Added a hint to enabling the fixture generation command via a comment in `/config/console.php`.

Note: The default paths resulting by the new `@tests` as accessed by the fixture commands are not what was expected in the discussion (`@tests/templates` and `@tests/fixtures`) but instead `@tests/unit/templates/fixtures` and `@tests/unit/fixtures`. The default values are configured in `yii\faker\FixtureController` so using the expected paths would require using `templatePath` and `fixtureDataPath` in the fixture controller map which wouldn't be a good approach to define defaults.