### PR TITLE
Prefer stable packages to leverage composer caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "source": "https://github.com/yiisoft/yii2"
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": ">=5.4.0",
         "yiisoft/yii2": ">=2.0.5",


### PR DESCRIPTION
Hello,

While using the framework I've noticed that the minimum stability for dependencies is "dev". This forces composer to re-download the same packages every time we issue a composer install on a clean checkout, which brings a lot of headaches when using in a CI environment. By turning on "prefer-stable" we leverage composer caching and boost the install time.

Thanks,
Nemanja