### PR TITLE
Fix #56: configure Codeception::Scpecify to not deep clone properties by default 

### DIFF
--- a/tests/codeception/_bootstrap.php
+++ b/tests/codeception/_bootstrap.php
@@ -14,3 +14,10 @@ $_SERVER['SERVER_NAME'] = parse_url(\Codeception\Configuration::config()['config
 $_SERVER['SERVER_PORT'] =  parse_url(\Codeception\Configuration::config()['config']['test_entry_url'], PHP_URL_PORT) ?: '80';
 
 Yii::setAlias('@tests', dirname(__DIR__));
+
+/**
+ * this configure codeception specify to not deep clone objects properties
+ * it can be configure localy in your tests
+ * @see https://github.com/Codeception/Specify/tree/master/docs
+ */
+\Codeception\Specify\Config::setDeepClone(false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #56

