### PR TITLE
fixed typo in example config

### DIFF
--- a/tests/codeception.yml
+++ b/tests/codeception.yml
@@ -4,7 +4,7 @@ actor: Tester
 #    enabled: true
 #    #remote: true
 #    #remote_config: '../tests/codeception.yml'
-#    white_list:
+#    whitelist:
 #        include:
 #            - ../models/*
 #            - ../controllers/*


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | ?

see also http://codeception.com/docs/11-Codecoverage

PS: `blacklist` has been removed in PHPUnit 5