### PR TITLE
Added codeception/specify to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "yiisoft/yii2-codeception": "*",
         "yiisoft/yii2-debug": "*",
         "yiisoft/yii2-gii": "*",
-        "yiisoft/yii2-faker": "*"
+        "yiisoft/yii2-faker": "*",
+        "codeception/specify": "*"
     },
     "config": {
         "process-timeout": 1800


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  |  Fixed Codeception --prefer-lowest build

It was an indirect dependency and #57 made Codeception builds with --prefer-lowest fail: https://travis-ci.org/Codeception/Codeception/jobs/145152589#L1653