### PR TITLE
Use PHP_EOL instead of ”\n“ for windows CLI output

### DIFF
--- a/commands/HelloController.php
+++ b/commands/HelloController.php
@@ -25,6 +25,6 @@ class HelloController extends Controller
      */
     public function actionIndex($message = 'hello world')
     {
-        echo $message . "\n";
+        echo $message . PHP_EOL;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| Is enhancement?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | no

