### PR TITLE
Fixed command to run coverage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,13 @@ to collect code coverage. You can run your tests and collect coverage with the f
 
 ```
 #collect coverage for all tests
-composer exec codecept run --coverage-html --coverage-xml
+composer exec codecept run -- --coverage-html --coverage-xml
 
 #collect coverage only for unit tests
-composer exec codecept run unit --coverage-html --coverage-xml
+composer exec codecept run unit -- --coverage-html --coverage-xml
 
 #collect coverage for unit and functional tests
-composer exec codecept run functional,unit --coverage-html --coverage-xml
+composer exec codecept run functional,unit -- --coverage-html --coverage-xml
 ```
 
 You can see code coverage output under the `tests/_output` directory.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

The command to run coverage return an error:

```sh
The "--coverage-html" option does not exist.
```

Need to add split to separate arguments for coverage commands.