### PR TITLE
Putting the proper paths for codeception code coverage

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -21,16 +21,16 @@ modules:
 #    #remote_config: '../tests/codeception.yml'
 #    whitelist:
 #        include:
-#            - ../models/*
-#            - ../controllers/*
-#            - ../commands/*
-#            - ../mail/*
+#            - models/*
+#            - controllers/*
+#            - commands/*
+#            - mail/*
 #    blacklist:
 #        include:
-#            - ../assets/*
-#            - ../config/*
-#            - ../runtime/*
-#            - ../vendor/*
-#            - ../views/*
-#            - ../web/*
-#            - ../tests/*
+#            - assets/*
+#            - config/*
+#            - runtime/*
+#            - vendor/*
+#            - views/*
+#            - web/*
+#            - tests/*


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

The tests folder was changed some time ago, however the paths have not been updated. I kept the comments on the lines. After running the tests with coverage without this change you get

```
$ vendor/codeception/base/codecept run functional --coverage-html
Codeception PHP Testing Framework v2.2.3
Powered by PHPUnit 4.8.27 by Sebastian Bergmann and contributors.


  [InvalidArgumentException]
  The "/basic/../models" directory does not exist.
```
-----------------------------------------------------------
After putting in the proper path you get
```
Code Coverage Report:
  2016-08-09 22:26:05

 Summary:
  Classes: 40.00% (2/5)
  Methods: 63.64% (14/22)
  Lines:   76.04% (73/96)

\app\controllers::SiteController
  Methods:  57.14% ( 4/ 7)   Lines:  89.47% ( 34/ 38)
\app\models::ContactForm
  Methods: 100.00% ( 3/ 3)   Lines: 100.00% ( 15/ 15)
\app\models::LoginForm
  Methods: 100.00% ( 4/ 4)   Lines: 100.00% ( 18/ 18)
\app\models::User
  Methods:  42.86% ( 3/ 7)   Lines:  40.00% (  6/ 15)
Remote CodeCoverage reports are not printed to console
```