### PR TITLE
Disable Yii2 cleanup in functional test suite

### DIFF
--- a/tests/functional.suite.yml
+++ b/tests/functional.suite.yml
@@ -11,3 +11,4 @@ modules:
     enabled:
       - Filesystem
       - Yii2
+          cleanup: false


### PR DESCRIPTION
Because it is on by default since Codeception 2.2.6 and it breaks builds of Codeception

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 