### PR TITLE
Simpler logout link

### DIFF
--- a/views/layouts/main.php
+++ b/views/layouts/main.php
@@ -42,14 +42,11 @@ AppAsset::register($this);
             Yii::$app->user->isGuest ? (
                 ['label' => 'Login', 'url' => ['/site/login']]
             ) : (
-                '<li>'
-                . Html::beginForm(['/site/logout'], 'post')
-                . Html::submitButton(
-                    'Logout (' . Yii::$app->user->identity->username . ')',
-                    ['class' => 'btn btn-link logout']
-                )
-                . Html::endForm()
-                . '</li>'
+                [
+                    'label' => 'Logout (' . Yii::$app->user->identity->username . ')',
+                    'url' => ['/site/logout'],
+                    'linkOptions' => ['data-method' => 'post']
+                ]
             )
         ],
     ]);


### PR DESCRIPTION
Why are we having a form here, if we could just use `data-method="post"` for the logout link (like in those links used for the *Delete* buttons in standard Yii2 widgets)?
Are there any reasons for the post form here?


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no