### PR TITLE
Move YII_ENV in console and web to env config file

### DIFF
--- a/config/env.php
+++ b/config/env.php
@@ -1,0 +1,5 @@
+<?php
+
+// comment out the following two lines when deployed to production
+defined('YII_DEBUG') or define('YII_DEBUG', true);
+defined('YII_ENV') or define('YII_ENV', 'dev');

--- a/web/index.php
+++ b/web/index.php
@@ -1,9 +1,6 @@
 <?php
 
-// comment out the following two lines when deployed to production
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'dev');
-
+require(__DIR__ . '/../config/env.php');
 require(__DIR__ . '/../vendor/autoload.php');
 require(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 

--- a/yii
+++ b/yii
@@ -8,9 +8,7 @@
  * @license http://www.yiiframework.com/license/
  */
 
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'dev');
-
+require(__DIR__ . '/config/env.php');
 require(__DIR__ . '/vendor/autoload.php');
 require(__DIR__ . '/vendor/yiisoft/yii2/Yii.php');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | none

I moved YII_ENV and YII_DEBUG directives to a single file in config folder so those configuration values are available and consistent in console command, migrations and web site.