### PR TITLE
Fix remote_config path in codeception.yml

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -19,7 +19,7 @@ modules:
 #    #c3_url: http://localhost:8080/index-test.php/
 #    enabled: true
 #    #remote: true
-#    #remote_config: '../tests/codeception.yml'
+#    #remote_config: '../codeception.yml'
 #    whitelist:
 #        include:
 #            - models/*


### PR DESCRIPTION
`../tests/codeception.yml` does not exist, using `../codeception.yml` works

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | N/A
