### PR TITLE
Composer "extra.asset-installer-paths" option deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,13 @@
         "codeception/specify": "~0.4.3"
     },
     "config": {
-        "process-timeout": 1800
+        "process-timeout": 1800,
+        "fxp-asset":{
+            "installer-paths": {
+                "npm-asset-library": "vendor/npm",
+                "bower-asset-library": "vendor/bower"
+            }
+        }
     },
     "scripts": {
         "post-create-project-cmd": [
@@ -48,10 +54,6 @@
             "generateCookieValidationKey": [
                 "config/web.php"
             ]
-        },
-        "asset-installer-paths": {
-            "npm-asset-library": "vendor/npm",
-            "bower-asset-library": "vendor/bower"
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes/no

According to [yii2-app-advanced#PR-243](https://github.com/yiisoft/yii2-app-advanced/issues/243) and [yii2-app-advanced#PR-251](https://github.com/yiisoft/yii2-app-advanced/pull/251) and [yii2-app-advanced#785c933ba31](https://github.com/yiisoft/yii2-app-advanced/commit/785c933ba31c0827dfdab92363898b461d7d40e3)
