### PR TITLE
Ensure alises match composer config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         "process-timeout": 1800,
         "fxp-asset":{
             "installer-paths": {
-                "npm-asset-library": "vendor/npm",
-                "bower-asset-library": "vendor/bower"
+                "npm-asset-library": "vendor/npm-asset",
+                "bower-asset-library": "vendor/bower-asset"
             }
         }
     },
@@ -62,8 +62,8 @@
             ]
         },
         "asset-installer-paths": {
-            "npm-asset-library": "vendor/npm",
-            "bower-asset-library": "vendor/bower"
+            "npm-asset-library": "vendor/npm-asset",
+            "bower-asset-library": "vendor/bower-asset"
         }
     },
     "repositories": [


### PR DESCRIPTION
Make sure composer-asset-plugin configuration matches what is configured
in application config:

https://github.com/yiisoft/yii2-app-basic/blob/2f2e2506c68080a60dc3f7d488ba30938aefbbc3/config/web.php#L10-L13

So it works with and without composer-asset-plugin.

/cc @SilverFire @samdark

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
