### PR TITLE
Application name instead of string literal in the navbar

### DIFF
--- a/views/layouts/main.php
+++ b/views/layouts/main.php
@@ -29,7 +29,7 @@ AppAsset::register($this);
 <div class="wrap">
     <?php
     NavBar::begin([
-        'brandLabel' => 'My Company',
+        'brandLabel' => Yii::$app->name,
         'brandUrl' => Yii::$app->homeUrl,
         'options' => [
             'class' => 'navbar-inverse navbar-fixed-top',


### PR DESCRIPTION
When not set in `config/web.php` the value of `Yii::$app->name` is `'My Company'` already.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no