### PR TITLE
updated asset-plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ You can then access the application through the following URL:
 http://localhost/basic/web/
 ~~~
 
+**NOTES:**
+- If you don not have `git` available on your machine, you can run composer commands with `FXP_ASSET__VCS_DRIVER_OPTIONS='{}' composer [...]` to use the GitHub API instead.
 
 CONFIGURATION
 -------------
@@ -104,7 +106,6 @@ return [
 - Yii won't create the database for you, this has to be done manually before you can access it.
 - Check and edit the other files in the `config/` directory to customize your application as required.
 - Refer to the README in the `tests` directory for information specific to basic application tests.
-
 
 
 TESTING

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ http://localhost/basic/web/
 ~~~
 
 
+**NOTES:**
+- If you don not have `git` available on your machine, you can run composer commands with `FXP_ASSET__VCS_DRIVER_OPTIONS='{}' composer [...]` to use the GitHub API instead.
+
+
 ### Install from an Archive File
 
 Extract the archive file downloaded from [yiiframework.com](http://www.yiiframework.com/download/) to
@@ -82,8 +86,6 @@ You can then access the application through the following URL:
 http://localhost/basic/web/
 ~~~
 
-**NOTES:**
-- If you don not have `git` available on your machine, you can run composer commands with `FXP_ASSET__VCS_DRIVER_OPTIONS='{}' composer [...]` to use the GitHub API instead.
 
 CONFIGURATION
 -------------

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,12 @@
             "installer-paths": {
                 "npm-asset-library": "vendor/npm",
                 "bower-asset-library": "vendor/bower"
-            }
+            },
+            "vcs-driver-options": {
+                "github-no-api": true
+            },
+            "git-skip-update": "2 days",
+            "pattern-skip-version": "(-build|-patch)"
         }
     },
     "scripts": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | when not having a git binary in your PATH
| Tests pass?   | ?

Brings down the application `create-project` command to a about 10 sec (with filled caches, on my machine).

Requires asset-plugin >=1.4 and a git binary.
