### PR TITLE
Remove trailing whitespaces in config/test.php

### DIFF
--- a/config/test.php
+++ b/config/test.php
@@ -7,18 +7,18 @@ $db = require __DIR__ . '/test_db.php';
  */
 return [
     'id' => 'basic-tests',
-    'basePath' => dirname(__DIR__),  
+    'basePath' => dirname(__DIR__),
     'aliases' => [
         '@bower' => '@vendor/bower-asset',
         '@npm'   => '@vendor/npm-asset',
-    ],  
+    ],
     'language' => 'en-US',
     'components' => [
         'db' => $db,
         'mailer' => [
             'useFileTransport' => true,
         ],
-        'assetManager' => [            
+        'assetManager' => [
             'basePath' => __DIR__ . '/../web/assets',
         ],
         'urlManager' => [
@@ -26,7 +26,7 @@ return [
         ],
         'user' => [
             'identityClass' => 'app\models\User',
-        ],        
+        ],
         'request' => [
             'cookieValidationKey' => 'test',
             'enableCsrfValidation' => false,
@@ -36,7 +36,7 @@ return [
                 'domain' => 'localhost',
             ],
             */
-        ],        
+        ],
     ],
     'params' => $params,
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

So CodeSniffer doesn't complains about extra whitespaces.
