### PR TITLE
since 2.0.13, the class name `Object` is invalid since PHP 7.2, use [BaseObject]] instead.

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -2,7 +2,7 @@
 
 namespace app\models;
 
-class User extends \yii\base\Object implements \yii\web\IdentityInterface
+class User extends \yii\base\BaseObject implements \yii\web\IdentityInterface
 {
     public $id;
     public $username;


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

