### PR TITLE
Add @bower and @npm aliases in config/console.php

### DIFF
--- a/config/console.php
+++ b/config/console.php
@@ -8,6 +8,10 @@ $config = [
     'basePath' => dirname(__DIR__),
     'bootstrap' => ['log'],
     'controllerNamespace' => 'app\commands',
+    'aliases' => [
+        '@bower' => '@vendor/bower-asset',
+        '@npm'   => '@vendor/npm-asset',
+    ],
     'components' => [
         'cache' => [
             'class' => 'yii\caching\FileCache',


### PR DESCRIPTION
You need them if you add the `yii\apidoc\commands\ApiController` and `GuideController` to your console application command map and you run them inside of your applications console app, as said in the yiisoft/yii2-apidoc 's README.md:

https://github.com/yiisoft/yii2-apidoc/blob/master/README.md

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #152
