### PR TITLE
Bump yii2-swiftmailer to ~2.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.4.0",
         "yiisoft/yii2": "~2.0.13",
         "yiisoft/yii2-bootstrap": "~2.0.0",
-        "yiisoft/yii2-swiftmailer": "~2.0.0"
+        "yiisoft/yii2-swiftmailer": "~2.1.0"
     },
     "require-dev": {
         "yiisoft/yii2-debug": "~2.0.0",


### PR DESCRIPTION
[Yii2 Swiftmailer Extension installation instructions](http://www.yiiframework.com/doc-2.0/ext-swiftmailer-index.html) says that we need to use `"yiisoft/yii2-swiftmailer": "~2.1.0"` in the `require` section of the `composer.json`. This change bumps extension version from `~2.0.0` to `~2.1.0`.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | 
| Tests pass?   | 
| Fixed issues  | 
