### PR TITLE
password set to empty string

### DIFF
--- a/controllers/SiteController.php
+++ b/controllers/SiteController.php
@@ -79,6 +79,8 @@ class SiteController extends Controller
         if ($model->load(Yii::$app->request->post()) && $model->login()) {
             return $this->goBack();
         }
+
+        $model->password = '';
         return $this->render('login', [
             'model' => $model,
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | -
| Fixed issues  | -

When login form is submitted with incorrect username and/or password, password value is set there in the input box when user is redirected back to login form.

This can be also done from view `@app/views/site/login.php` in the html form, but I think modifying its value in controller is a good approach.

If this PR is merged, I can also create similar PR for yii2-app-advanced.
