### PR TITLE
Changes to run vagrant from project root dir

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,9 +10,11 @@ domains = {
   app: 'yii2basic.dev'
 }
 
+vagrantfile_dir_path = File.dirname(__FILE__)
+
 config = {
-  local: './vagrant/config/vagrant-local.yml',
-  example: './vagrant/config/vagrant-local.example.yml'
+  local: vagrantfile_dir_path + '/vagrant/config/vagrant-local.yml',
+  example: vagrantfile_dir_path + '/vagrant/config/vagrant-local.example.yml'
 }
 
 # copy config from example if local config not exists


### PR DESCRIPTION
Introduced a variable which represents current vagrantfile directory path. This way we can run vagrant directly from the Yii2 project root and do not need to store vagrant configurations separately.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
