### PR TITLE
Partially Fixes #177 Nginx default config interferes with dev domain.…

### DIFF
--- a/vagrant/provision/once-as-root.sh
+++ b/vagrant/provision/once-as-root.sh
@@ -62,6 +62,10 @@ info "Enabling site configuration"
 ln -s /app/vagrant/nginx/app.conf /etc/nginx/sites-enabled/app.conf
 echo "Done!"
 
+info "Removing default site configuration"
+rm /etc/nginx/sites-enabled/default
+echo "Done!"
+
 info "Initailize databases for MySQL"
 mysql -uroot <<< "CREATE DATABASE yii2basic"
 mysql -uroot <<< "CREATE DATABASE yii2basic_test"


### PR DESCRIPTION
… Still causes an issue with SSL redirect.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #177 Vagrant up did not delete `default` nginx config 
