### PR TITLE
Add fixtures in Yii2 module

### DIFF
--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -8,4 +8,4 @@ modules:
     enabled:
       - Asserts
       - Yii2:
-            part: [orm, email]
+            part: [orm, email, fixtures]


### PR DESCRIPTION
To be able to follow the instruction on https://www.yiiframework.com/doc/guide/2.0/en/test-fixtures `$I->grabFixture()` we need to enable the fixtures feature of the Yii2. Methinks this would be a good thing to enable by default.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
