### PR TITLE
Remove setting cleanup false

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -12,7 +12,6 @@ modules:
     config:
         Yii2:
             configFile: 'config/test.php'
-            cleanup: false
 
 # To enable code coverage:
 #coverage:


### PR DESCRIPTION
It is not clear why cleanup is set to false in the template. ActiveFixture fixture data is not loaded when a previous test had fixtures.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
