### PR TITLE
changed vagrant top-level domain to .test

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ required_plugins.each do |plugin|
 end
 
 domains = {
-  app: 'yii2basic.dev'
+  app: 'yii2basic.test'
 }
 
 vagrantfile_dir_path = File.dirname(__FILE__)

--- a/vagrant/nginx/app.conf
+++ b/vagrant/nginx/app.conf
@@ -6,7 +6,7 @@ server {
    listen 80; ## listen for ipv4
    #listen [::]:80 default_server ipv6only=on; ## listen for ipv6
 
-   server_name yii2basic.dev;
+   server_name yii2basic.test;
    root        /app/web/;
    index       index.php;
 


### PR DESCRIPTION
Changes to top-level domain for vagrant to .test to avoid https redirect in some browsers.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | fixes #187 
