### PR TITLE
Old array syntax in requirement checker (could be run in PHP prior to 5.4)

### DIFF
--- a/requirements.php
+++ b/requirements.php
@@ -16,10 +16,10 @@
 
 
 if (!isset($frameworkPath)) {
-    $searchPaths = [
+    $searchPaths = array(
         dirname(__FILE__) . '/vendor/yiisoft/yii2',
         dirname(__FILE__) . '/../vendor/yiisoft/yii2',
-    ];
+    );
     foreach($searchPaths as $path) {
         if (is_dir($path)) {
             $frameworkPath = $path;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
