### PR TITLE
fix warning message in test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "yiisoft/yii2-faker": "~2.0.0",
 
         "codeception/base": "~2.3.0",
-        "codeception/verify": "~0.4.0",
+        "codeception/verify": "~1.0",
         "codeception/specify": "~0.4.6",
         "symfony/browser-kit": ">=2.7 <=4.2.4"
     },

--- a/tests/unit/models/ContactFormTest.php
+++ b/tests/unit/models/ContactFormTest.php
@@ -43,6 +43,6 @@ class ContactFormTest extends \Codeception\Test\Unit
         expect($emailMessage->getFrom())->hasKey('noreply@example.com');
         expect($emailMessage->getReplyTo())->hasKey('tester@example.com');
         expect($emailMessage->getSubject())->equals('very important letter subject');
-        expect($emailMessage->toString())->contains('body of current message');
+        expect($emailMessage->toString())->stringContainsString('body of current message');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | fix warning message: Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead. Using assertNotContains() with string haystacks is deprecated and will not be supported in PHPUnit 9.
