### PR TITLE
Temporary remove names from emails

### DIFF
--- a/models/ContactForm.php
+++ b/models/ContactForm.php
@@ -52,8 +52,8 @@ class ContactForm extends Model
         if ($this->validate()) {
             Yii::$app->mailer->compose()
                 ->setTo($email)
-                ->setFrom([Yii::$app->params['senderEmail'] => Yii::$app->params['senderName']])
-                ->setReplyTo([$this->email => $this->name])
+                ->setFrom(Yii::$app->params['senderEmail']) // Temporary remove Yii::$app->params['senderName']
+                ->setReplyTo($this->email) // Temporary remove $this->name
                 ->setSubject($this->subject)
                 ->setTextBody($this->body)
                 ->send();


### PR DESCRIPTION
Temporary remove names from `setFrom()` and `setReplyTo()` to allow correct sending contact form by default without errors, till the related issue of [swiftMailer solved](https://github.com/yiisoft/yii2-swiftmailer/issues/51)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes/no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
