### PR TITLE
Fix #223: Do not start session for Alert widget in case no session ID…

### DIFF
--- a/widgets/Alert.php
+++ b/widgets/Alert.php
@@ -50,6 +50,9 @@ class Alert extends \yii\bootstrap\Widget
     public function run()
     {
         $session = Yii::$app->session;
+        if ($session->getHasSessionId() === false) {
+            return;
+        }
         $flashes = $session->getAllFlashes();
         $appendClass = isset($this->options['class']) ? ' ' . $this->options['class'] : '';
 


### PR DESCRIPTION
… was passed

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #223
