### PR TITLE
Enh: Vagrant is not stopped, after the installation of each plugin

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,19 @@
 require 'yaml'
 require 'fileutils'
 
+required_plugins_installed = nil
 required_plugins = %w( vagrant-hostmanager vagrant-vbguest )
 required_plugins.each do |plugin|
-    exec "vagrant plugin install #{plugin}" unless Vagrant.has_plugin? plugin
+  unless Vagrant.has_plugin? plugin
+    system "vagrant plugin install #{plugin}"
+    required_plugins_installed = true
+  end
+end
+
+# IF plugin[s] was just installed - restart required
+if required_plugins_installed
+  system "vagrant up"
+  exit
 end
 
 domains = {


### PR DESCRIPTION
If `required_plugins` were not installed, the Vagrant startup process will stop after the installation of each of them.
_It's good that there only two required plugins - three launches, and we will reach the goal!_ 😅
Now it's fixed and Vagrant startup process doesn't stop.
**P.S.** Alternatively, you can use the [relatively new Vagrant feature](https://www.vagrantup.com/docs/vagrantfile/vagrant_settings#available-settings) `config.vagrant.plugins = %w( vagrant-hostmanager vagrant-vbguest )` it will prompt the user to install all plugins at once. But, then need to run Vagrant manually, again.


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | 
