### PR TITLE
Add virtual machine IP to the Yii2 "allowedIPs" [ci skip]

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,7 +72,7 @@ Vagrant.configure(2) do |config|
   # config.vbguest.auto_update = false
 
   # provisioners
-  config.vm.provision 'shell', path: './vagrant/provision/once-as-root.sh', args: [options['timezone']]
+  config.vm.provision 'shell', path: './vagrant/provision/once-as-root.sh', args: [options['timezone'], options['ip']]
   config.vm.provision 'shell', path: './vagrant/provision/once-as-vagrant.sh', args: [options['github_token']], privileged: false
   config.vm.provision 'shell', path: './vagrant/provision/always-as-root.sh', run: 'always'
 

--- a/vagrant/provision/once-as-root.sh
+++ b/vagrant/provision/once-as-root.sh
@@ -3,6 +3,7 @@
 #== Import script args ==
 
 timezone=$(echo "$1")
+readonly IP=$2
 
 #== Bash helpers ==
 
@@ -20,6 +21,9 @@ export DEBIAN_FRONTEND=noninteractive
 
 info "Configure timezone"
 timedatectl set-timezone ${timezone} --no-ask-password
+
+info "Add the VM IP to the list of allowed IPs"
+awk -v ip=$IP -f /app/vagrant/provision/provision.awk /app/config/web.php
 
 info "Prepare root password for MySQL"
 debconf-set-selections <<< "mariadb-server-10.0 mysql-server/root_password password \"''\""

--- a/vagrant/provision/provision.awk
+++ b/vagrant/provision/provision.awk
@@ -1,0 +1,50 @@
+###
+# Modifying Yii2's files for Vagrant VM
+#
+# @author HA3IK <golubha3ik@gmail.com>
+# @version 1.0.0
+
+BEGIN {
+    print "AWK BEGINs its work:"
+    IGNORECASE = 1
+
+    # Correct IP - wildcard last octet
+    match(ip, /(([0-9]+\.)+)/, arr)
+    ip = arr[1] "*"
+}
+# BODY
+{
+    # Check if it's the same file
+    if (FILENAME != isFile["same"]){
+        msg = "- Work with: " FILENAME
+        # Close a previous file
+        close(isFile["same"])
+        # Delete previous data
+        delete isFile
+        # Save current file
+        isFile["same"] = FILENAME
+        # Define array index for the file
+        switch (FILENAME){
+        case /config\/web\.php$/:
+            isFile["IsConfWeb"] = 1
+            msg = msg " - add allowed IP: " ip
+            break
+        }
+        # Print the concatenated message for the file
+        print msg
+    }
+
+    # IF config/web.php
+    if (isFile["IsConfWeb"]){
+        # IF line has "allowedIPs" and doesn't has our IP
+        if (match($0, "allowedIPs") && !match($0, ip)){
+            match($0, /([^\]]+)(.+)/, arr)
+            $0 = sprintf("%s, '%s'%s", arr[1], ip, arr[2])
+        }
+        # Rewrite the file
+        print $0 > FILENAME
+    }
+}
+END {
+    print "AWK ENDs its work."
+}


### PR DESCRIPTION
Vagrant's virtual machine IP is not in the `allowedIPs` list.
By default, Yii2's Vagrant CIDR notation is 192.168.83.137/24, so we convert it to 192.168.83.* and add to each of the `allowedIPs` lists in the "config/web.php" file.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | 
