### PR TITLE
Bug: Updated Vagrant box to Ubuntu 18.04 with PHP 7.2 etc (#176)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ end
 # vagrant configurate
 Vagrant.configure(2) do |config|
   # select the box
-  config.vm.box = 'bento/ubuntu-16.04'
+  config.vm.box = 'bento/ubuntu-18.04'
 
   # should we ask about box updates?
   config.vm.box_check_update = options['box_check_update']

--- a/vagrant/nginx/app.conf
+++ b/vagrant/nginx/app.conf
@@ -28,7 +28,7 @@ server {
        include fastcgi_params;
        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
        #fastcgi_pass   127.0.0.1:9000;
-       fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+       fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
        try_files $uri =404;
    }
 

--- a/vagrant/provision/always-as-root.sh
+++ b/vagrant/provision/always-as-root.sh
@@ -13,6 +13,6 @@ function info {
 info "Provision-script user: `whoami`"
 
 info "Restart web-stack"
-service php7.0-fpm restart
+service php7.2-fpm restart
 service nginx restart
 service mysql restart

--- a/vagrant/provision/once-as-root.sh
+++ b/vagrant/provision/once-as-root.sh
@@ -35,7 +35,7 @@ apt-get update
 apt-get upgrade -y
 
 info "Install additional software"
-apt-get install -y php7.0-curl php7.0-cli php7.0-intl php7.0-mysqlnd php7.0-gd php7.0-fpm php7.0-mbstring php7.0-xml unzip nginx mariadb-server-10.0 php.xdebug
+apt-get install -y php7.2-curl php7.2-cli php7.2-intl php7.2-mysqlnd php7.2-gd php7.2-fpm php7.2-mbstring php7.2-xml unzip nginx mariadb-server-10.1 php.xdebug
 
 info "Configure MySQL"
 sed -i 's/.*bind-address.*/bind-address = 0.0.0.0/' /etc/mysql/mariadb.conf.d/50-server.cnf
@@ -46,10 +46,10 @@ mysql <<< 'FLUSH PRIVILEGES'
 echo "Done!"
 
 info "Configure PHP-FPM"
-sed -i 's/user = www-data/user = vagrant/g' /etc/php/7.0/fpm/pool.d/www.conf
-sed -i 's/group = www-data/group = vagrant/g' /etc/php/7.0/fpm/pool.d/www.conf
-sed -i 's/owner = www-data/owner = vagrant/g' /etc/php/7.0/fpm/pool.d/www.conf
-cat << EOF > /etc/php/7.0/mods-available/xdebug.ini
+sed -i 's/user = www-data/user = vagrant/g' /etc/php/7.2/fpm/pool.d/www.conf
+sed -i 's/group = www-data/group = vagrant/g' /etc/php/7.2/fpm/pool.d/www.conf
+sed -i 's/owner = www-data/owner = vagrant/g' /etc/php/7.2/fpm/pool.d/www.conf
+cat << EOF > /etc/php/7.2/mods-available/xdebug.ini
 zend_extension=xdebug.so
 xdebug.remote_enable=1
 xdebug.remote_connect_back=1


### PR DESCRIPTION
Vagrant box was updated to Ubuntu 18.04 LTS ([bento/ubuntu-18.04](https://app.vagrantup.com/bento/boxes/ubuntu-18.04)), with all the attendant consequences: _PHP v7.2; MariaDB v10.1; NGINX v1.14.0; PHPUnit 8.5.8; Git v2.17.1; etc_.
Prev box [bento/ubuntu-16.04](https://app.vagrantup.com/bento/boxes/ubuntu-16.04) was with: _PHP v7.0; MariaDB v10.0; NGINX v1.10.3; PHPUnit 6.5.14; Git v2.7.4; etc_.
Everything was tested, used, and works well 👍


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | #176
