### PR TITLE
Bug: rm "blacklist" from the codeception.yml; corrected "TESTING" instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,13 +221,13 @@ to collect code coverage. You can run your tests and collect coverage with the f
 
 ```
 #collect coverage for all tests
-vendor/bin/codecept run -- --coverage-html --coverage-xml
+vendor/bin/codecept run --coverage --coverage-html --coverage-xml
 
 #collect coverage only for unit tests
-vendor/bin/codecept run unit -- --coverage-html --coverage-xml
+vendor/bin/codecept run unit --coverage --coverage-html --coverage-xml
 
 #collect coverage for unit and functional tests
-vendor/bin/codecept run functional,unit -- --coverage-html --coverage-xml
+vendor/bin/codecept run functional,unit --coverage --coverage-html --coverage-xml
 ```
 
 You can see code coverage output under the `tests/_output` directory.

--- a/codeception.yml
+++ b/codeception.yml
@@ -25,12 +25,3 @@ modules:
 #            - controllers/*
 #            - commands/*
 #            - mail/*
-#    blacklist:
-#        include:
-#            - assets/*
-#            - config/*
-#            - runtime/*
-#            - vendor/*
-#            - views/*
-#            - web/*
-#            - tests/*


### PR DESCRIPTION
Those ["TESTING" instructions, in README.md](/yiisoft/yii2-app-basic/blob/master/README.md#testing), didn't work.
The "blacklist" section was deleted because of:
> "Codeception\Coverage\Filter: The blacklist functionality has been removed from PHPUnit 5, please remove blacklist section from configuration."


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | 
