### PR TITLE
Bug: Each DB `yii2_basic_tests` name is renamed to `yii2basic_test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ services:
   - mysql
 
 before_install:
-  - mysql -e 'CREATE DATABASE IF NOT EXISTS yii2_basic_tests;'
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS yii2basic_test;'
 
 install:
   - travis_retry composer self-update && composer --version

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ To execute acceptance tests do the following:
     docker run --net=host selenium/standalone-firefox:2.53.0
     ```
 
-5. (Optional) Create `yii2_basic_tests` database and update it by applying migrations if you have them.
+5. (Optional) Create `yii2basic_test` database and update it by applying migrations if you have them.
 
    ```
    tests/bin/yii migrate

--- a/config/test_db.php
+++ b/config/test_db.php
@@ -1,6 +1,6 @@
 <?php
 $db = require __DIR__ . '/db.php';
 // test database! Important not to run tests on production or development databases
-$db['dsn'] = 'mysql:host=localhost;dbname=yii2_basic_tests';
+$db['dsn'] = 'mysql:host=localhost;dbname=yii2basic_test';
 
 return $db;


### PR DESCRIPTION
Renamed strange `yii2_basic_tests `DB name to `yii2basic_test `which was created by "provision"

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  |
