### PR TITLE
Bug: Repeat CLI command after Vagrant plugin[s] installation nonstop

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,8 @@ end
 
 # IF plugin[s] was just installed - restart required
 if required_plugins_installed
-  system "vagrant up"
+  # Get CLI command[s] and call again
+  system 'vagrant' + ARGV.to_s.gsub(/\[\"|\", \"|\"\]/, ' ')
   exit
 end
 


### PR DESCRIPTION
**Problem:** 
If a user, who has no `required_plugins` installed, calls the command `vagrant --help` or `vagrant ssh --help` etc.
Then, after installing all the plugins, always be called the command: `vagrant up` 😅
**Now it's fixed** 👍
And when someone calls the command `vagrant --help`, he will receive the command `vagrant --help` etc.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | 
