### PR TITLE
Remove composer.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,6 @@ Thumbs.db
 # composer itself is not needed
 composer.phar
 
-# composer lock
-composer.lock
-
 # Mac DS_Store Files
 .DS_Store
 


### PR DESCRIPTION
`composer.lock` should not be git-ignored in a template project
Neither should it be committed, but it isn't :)

Fixes #303

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes - also with fresh dependencies, though CI would tell you, too
| Fixed issues  | #303 
