### PR TITLE
Remove explicit phpunit/phpunit requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "yiisoft/yii2-debug": "~2.1.0",
         "yiisoft/yii2-gii": "~2.2.0",
         "yiisoft/yii2-faker": "~2.0.0",
-        "phpunit/phpunit": "~9.5.0",
         "codeception/codeception": "^5.0.0 || ^4.0",
         "codeception/lib-innerbrowser": "^4.0 || ^3.0 || ^1.1",
         "codeception/module-asserts": "^3.0 || ^1.1",


### PR DESCRIPTION
phpunit is not explicitly required, all the included tests run with codeception, not phpunit (not directly, at least).

Fixes #308

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #308 
