### PR TITLE
Change: updated checkout version in GH from v2 to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Setup cache environment
         id: cache-env


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Updated GH Action
Upgrade the GitHub checkout version from v2 to the latest v5, as v2 is outdated.

Latest release
https://github.com/actions/checkout/releases/tag/v5.0.0
